### PR TITLE
Revert "Rename to strip-html"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-![Node](https://img.shields.io/node/v/vue-strip-html)
-[![NPM](https://img.shields.io/npm/v/vue-strip-html)](https://www.npmjs.com/package/vue-strip-html)
+![Node](https://img.shields.io/node/v/vue-safe-html)
+[![NPM](https://img.shields.io/npm/v/vue-safe-html)](https://www.npmjs.com/package/vue-safe-html)
 [![Vue.js](https://img.shields.io/badge/vue-2-green.svg)](https://vuejs.org)
 
-# vue-strip-html
+# vue-safe-html
 
-A Vue directive which renders sanitised HTML dynamically.
+A Vue directive which renders sanitised HTML dynamically. Zero-dependency,
 
 ## Installation
 
 Install package:
 
 ```sh
-npm install @ecosia/vue-strip-html
+npm install @ecosia/vue-safe-html
 # OR
-yarn add @ecosia/vue-strip-html
+yarn add @ecosia/vue-safe-html
 ```
 
 Use the plugin:
 
 ```js
 import Vue from 'vue';
-import VueStripHTML from '@ecosia/vue-strip-html';
+import VueSafeHTML from '@ecosia/vue-safe-html';
 
-Vue.use(VueStripHTML);
+Vue.use(VueSafeHTML);
 ```
 
 ## Usage
@@ -31,15 +31,15 @@ In your component:
 
 ```html
 <template>
-  <div v-strip-html="myUnstrippedHTML">
+  <div v-safe-html="myUnsafeHTML">
 </template>
 ```
 
 ```js
 export default {
   computed: {
-    myUnstrippedHTML() {
-      return '<script>Oh my!</script> I am stripped!';
+    myUnsafeHTML() {
+      return '<script>oh my!</script> I am safe!';
     }
   }
 }
@@ -48,7 +48,7 @@ export default {
 Renders to:
 
 ```html
-<div>I am stripped!</div>
+<div>I am safe!</div>
 ```
 
 ### Options
@@ -60,7 +60,7 @@ Array of strings. Default: `['a', 'b', 'br', 'strong', 'i', 'em', 'mark', 'small
 Customize the tags that are allowed to be rendered, either by providing new ones:
 
 ```js
-Vue.use(VueStripHTML, {
+Vue.use(VueSafeHTML, {
   allowedTags: ['marquee', 'blockquote'],
 });
 ```
@@ -68,9 +68,9 @@ Vue.use(VueStripHTML, {
 Or extending the default ones:
 
 ```js
-import VueStripHTML, { allowedTags } from '@ecosia/vue-strip-html';
+import VueSafeHTML, { allowedTags } from '@ecosia/vue-safe-html';
 
-Vue.use(VueStripHTML, {
+Vue.use(VueSafeHTML, {
   allowedTags: [...allowedTags, 'marquee', 'blockquote'],
 });
 ```
@@ -78,25 +78,16 @@ Vue.use(VueStripHTML, {
 If no tags are passed, all tags are stripped:
 
 ```js
-import VueStripHTML, { allowedTags } from '@ecosia/vue-strip-html';
+import VueSafeHTML, { allowedTags } from '@ecosia/vue-safe-html';
 
-Vue.use(VueStripHTML, {
+Vue.use(VueSafeHTML, {
   allowedTags: [],
 });
 ```
 
-It is also possible to provide custom allowed tags directly to the directive tag, using directive modifiers. This allows local override of the option:
-
-```html
-<template>
-  <!-- only allow p and strong tags -->
-  <div v-strip-html.p.strong="myUnstrippedHTML">
-</template>
-```
-
 ### Nuxt
 
-`vue-strip-html` is written as a Vue plugin so you can easily use it inside Nuxt by following [the Nuxt documentation](https://nuxtjs.org/docs/2.x/directory-structure/plugins#vue-plugins).
+`vue-safe-html` is written as a Vue plugin so you can easily use it inside Nuxt by following [the Nuxt documentation](https://nuxtjs.org/docs/2.x/directory-structure/plugins#vue-plugins).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,10 @@
 {
-  "name": "vue-strip-html",
+  "name": "vue-safe-html",
   "version": "1.0.0",
   "description": "A Vue directive which renders sanitised HTML dynamically",
   "main": "dist/main.js",
-  "repository": "git@github.com:ecosia/vue-strip-html.git",
+  "repository": "git@github.com:ecosia/vue-safe-html.git",
   "author": "Ecosia GmbH <info@ecosia.org>",
-  "contributors": [
-    "Emanuele Marchi (https://github.com/LostCrew)",
-    "Jakub Fiala (https://github.com/jakubfiala)",
-    "Markus Waitl (https://github.com/axlwaii)"
-  ],
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@ import createDirective from './directive';
 
 export default {
   install: (Vue, options = {}) => {
-    Vue.directive('strip-html', createDirective(options.allowedTags));
+    Vue.directive('safe-html', createDirective(options.allowedTags));
   },
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -15,14 +15,14 @@ describe('Plugin', () => {
       expect(Plugin.install).toBeInstanceOf(Function);
       Plugin.install(localVue);
       expect(localVue.directive).toHaveBeenCalledTimes(1);
-      expect(localVue.directive.mock.calls[0][0]).toBe('strip-html');
+      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
       expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
     });
 
     it('Installs directive with custom allowed tags', () => {
       const allowedTags = ['a', 'button'];
       Plugin.install(localVue, { allowedTags });
-      expect(localVue.directive.mock.calls[0][0]).toBe('strip-html');
+      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
       expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
     });
   });
@@ -33,21 +33,21 @@ describe('Plugin', () => {
 
     it('Sanitizes given string', () => {
     // eslint-disable-next-line vue/one-component-per-file
-      const Component = localVue.component('StripHtmlComponent', {
-        template: '<div v-strip-html="\'<p><strong>Stripped</strong> HTML<script></script></p>\'"></div>',
+      const Component = localVue.component('SafeHtmlComponent', {
+        template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
       });
       const wrapper = shallowMount(Component, { localVue });
-      const expected = '<div><strong>Stripped</strong> HTML</div>';
+      const expected = '<div><strong>Safe</strong> HTML</div>';
       expect(wrapper.html()).toBe(expected);
     });
 
     it('Sanitizes with custom allowed tags', () => {
     // eslint-disable-next-line vue/one-component-per-file
-      const Component = localVue.component('StripHtmlComponent', {
-        template: '<div v-strip-html.span="\'<p><strong><span>Stripped</span></strong> HTML<script></script></p>\'"></div>',
+      const Component = localVue.component('SafeHtmlComponent', {
+        template: '<div v-safe-html.span="\'<p><strong><span>Safe</span></strong> HTML<script></script></p>\'"></div>',
       });
       const wrapper = shallowMount(Component, { localVue });
-      const expected = '<div><span>Stripped</span> HTML</div>';
+      const expected = '<div><span>Safe</span> HTML</div>';
       expect(wrapper.html()).toBe(expected);
     });
   });

--- a/src/index.test3.js
+++ b/src/index.test3.js
@@ -4,17 +4,17 @@ import Plugin from './index';
 describe('Integration', () => {
   it('Sanitizes given string', () => {
     const wrapper = shallowMount({
-      template: '<div v-strip-html="\'<p><strong>Strip</strong> HTML<script></script></p>\'"></div>',
+      template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
     }, { global: { plugins: [Plugin] } });
-    const expected = '<div><strong>Strip</strong> HTML</div>';
+    const expected = '<div><strong>Safe</strong> HTML</div>';
     expect(wrapper.html()).toBe(expected);
   });
 
   it('Sanitizes with custom allowed tags', () => {
     const wrapper = shallowMount({
-      template: '<div v-strip-html.span="\'<p><strong><span>Strip</span></strong> HTML<script></script></p>\'"></div>',
+      template: '<div v-safe-html.span="\'<p><strong><span>Safe</span></strong> HTML<script></script></p>\'"></div>',
     }, { global: { plugins: [Plugin] } });
-    const expected = '<div><span>Strip</span> HTML</div>';
+    const expected = '<div><span>Safe</span> HTML</div>';
     expect(wrapper.html()).toBe(expected);
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,9 @@ module.exports = {
   output: {
     filename: 'main.js',
     path: resolve(__dirname, 'dist'),
-    library: 'VueStripHTML',
+    library: 'VueSafeHTML',
     libraryTarget: 'umd',
-    globalObject: '(typeof self !== \'undefined\' ? self : this)',
+    globalObject: `(typeof self !== 'undefined' ? self : this)`,
   },
   mode: 'production',
   module: {


### PR DESCRIPTION
Reverts ecosia/vue-strip-html#28

Upon discussion, `vue-safe-html` is just a better name to accomodate various options provisioning methods.